### PR TITLE
Earn 2x speed on threaded C++ algorithm

### DIFF
--- a/cpp/test.sh
+++ b/cpp/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Compile threaded"
+g++ --std=c++11 -W -Wall -Wextra -Wshadow-local idriss-thread.cpp -o idriss-threaded -lpthread
+
+echo "Compile no thread"
+g++ --std=c++11 -W -Wall -Wextra -Wshadow-local idriss-nothread.cpp -o idriss-nothread
+
+echo ""
+echo "================="
+echo "Run threaded"
+time ./idriss-threaded $1 $2
+
+echo ""
+echo "================="
+echo "Run no thread"
+time ./idriss-nothread $1 $2


### PR DESCRIPTION
Initially I tried replacing my home made ThreadSafeQueue by
https://github.com/bshoshany/thread-pool (almost the same API): but it
did not change the speed (twice slower than non-threaded algorithm). So
I tried something else: since the use of mutex is slow: we have to
create N FIFOs and N counters (where N is the number of jobs (aka
workers) ~= 2 * CPU cores): 1 FIFO by thread so no more concurrency on
accessing elements in FIFOs. But we have to fill them with some initial
values. Therefore the algorithm is duplicated: the initial algorithm
computes the N values (N == number of workers) then we move them one by
one into other FIFO threads. Then each thread compute the algorithm and
store into N counters (X). Finally we sum all counters. I still do not
understand why I only earn two times faster instead of N times faster!!!